### PR TITLE
not building web extension through partykit

### DIFF
--- a/partykit.json
+++ b/partykit.json
@@ -1,9 +1,5 @@
 {
   "name": "multiplayer-github",
   "main": "src/server.ts",
-  "compatibilityDate": "2023-10-03",
-  "build": {
-    "command": "npm run build:extension",
-    "watch": "web-extension"
-  }
+  "compatibilityDate": "2023-10-03"
 }


### PR DESCRIPTION
we were getting a code 7 error in the deploy to partykit step. I believe because in our partykit deploy we were trying to build the web extension but we require the partykit to deploy before we build the web extension so we were getting errors.